### PR TITLE
Consolidate entry point and restore modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,14 @@
-```
 # Raspberry Pi 5de MQTT 发布/订阅 系统部署指南
 
 本项目示例演示如何在 **Raspberry Pi 5de (pi5de)** 上部署一个基于 `paho-mqtt` 的 MQTT 发布者（Publisher）和订阅者（Subscriber），用于温度数据的采集与联动。你可以在局域网内快速搭建轻量级消息系统，并结合 GPIO 控制实现自动化场景。
-```
 
 ## 目录
 
 - [项目简介](#项目简介)
-- [硬件环境](#硬件环境)
-- [软件环境](#软件环境)
+- [组件关系](#组件关系)
+- [示例代码](#示例代码)
 - [部署步骤](#部署步骤)
-  - [1. 系统更新](#1-系统更新)
-  - [2. 安装 Python 依赖](#2-安装-python-依赖)
-  - [3. 获取代码](#3-获取代码)
-  - [4. 配置 Broker 地址](#4-配置-broker-地址)
-  - [5. 运行订阅者](#5-运行订阅者)
-  - [6. 运行发布者](#6-运行发布者)
 - [进阶功能](#进阶功能)
-- [常见问题](#常见问题)
 - [许可证](#许可证)
 
 ---
@@ -39,6 +30,49 @@
 - **MQTT 客户端库（paho-mqtt）**：Eclipse Paho 提供的 Python 客户端库，用于在 Publisher 和 Subscriber 中实现与 Broker 的通信，支持消息的发布（publish）和订阅（subscribe）。
 
 ---
+## 示例代码
+
+仓库提供 `main.py` 作为入口文件，通过命令行参数选择发布（publish）或订阅（subscribe）模式，内部调用 `publisher.py` 或 `subscriber.py` 实现逻辑。
+
+```python
+parser = argparse.ArgumentParser()
+parser.add_argument("mode", choices=["publish", "subscribe"])
+args = parser.parse_args()
+```
+
+根据参数决定调用 `publisher.start_publisher()` 或 `subscriber.start_subscriber()`。
+
+```python
+if args.mode == "publish":
+    publisher.start_publisher(mqtt.Client())
+else:
+    subscriber.start_subscriber()
+```
+
+`start_publisher()` 主要逻辑：
+
+```python
+import json
+import time
+import random
+import paho.mqtt.client as mqtt
+
+client = mqtt.Client()
+
+while True:
+    temperature = round(random.uniform(20.0, 30.0), 2)
+    payload = json.dumps({"temperature": temperature})
+    client.publish(TOPIC, payload)
+    time.sleep(5)
+```
+
+`start_subscriber()` 主要逻辑：
+
+```python
+def on_message(client, userdata, msg):
+    data = json.loads(msg.payload.decode())
+    print(f"[{msg.topic}] 收到消息：{data}")
+```
 
 ## 部署步骤
 
@@ -48,22 +82,29 @@
 sudo apt update && sudo apt upgrade -y
 ```
 
-### 2. 安装 Python 依赖
+### 2. 安装 Mosquitto Broker
+
+```bash
+sudo apt install mosquitto mosquitto-clients -y
+sudo systemctl enable --now mosquitto
+```
+
+### 3. 安装 Python 依赖
 
 ```bash
 sudo apt install python3-pip -y
 pip3 install paho-mqtt
 ```
 
-### 3. 获取代码
+### 4. 获取代码
 
 ```bash
 # 克隆或下载本仓库
-git clone https://github.com/yourusername/RaspberryPier.git
-cd RaspberryPier/mqtt
+git clone https://github.com/yourusername/pi5-mqtt-tools.git
+cd pi5-mqtt-tools
 ```
 
-### 4. 配置 Broker 地址
+### 5. 配置 Broker 地址
 
 编辑 `publisher.py` 和 `subscriber.py` 中的连接参数：
 
@@ -73,10 +114,10 @@ BROKER_PORT = 1883
 TOPIC = "home/sensor/temperature"
 ```
 
-### 5. 运行订阅者
+### 6. 运行订阅者
 
 ```bash
-python3 subscriber.py
+python3 main.py subscribe
 ```
 
 日志示例：
@@ -86,10 +127,10 @@ Connected with result code 0
 [home/sensor/temperature] 收到消息：25.34
 ```
 
-### 6. 运行发布者
+### 7. 运行发布者
 
 ```bash
-python3 publisher.py
+python3 main.py publish
 ```
 
 每隔 5 秒发布一次模拟温度：
@@ -105,7 +146,7 @@ python3 publisher.py
 1. **结构化 JSON 消息**：发送包含时间戳、传感器 ID 的 JSON 数据。
 2. **QoS 与遗嘱消息**：提高可靠性，处理断线场景。
 3. **GPIO 联动**：收到高温报警时控制风扇或 LED。\
-   示例请参考 `subscriber.py` 中的 GPIO 代码块。
+   示例可在 `start_subscriber()` 函数中添加 GPIO 控制逻辑。
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+import argparse
+
+import paho.mqtt.client as mqtt
+
+import publisher
+import subscriber
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MQTT 发布/订阅示例")
+    parser.add_argument(
+        "mode", choices=["publish", "subscribe"], help="选择运行模式 (publish / subscribe)"
+    )
+    args = parser.parse_args()
+
+    if args.mode == "publish":
+        client = mqtt.Client()
+        publisher.start_publisher(client)
+    else:
+        subscriber.start_subscriber()
+
+
+if __name__ == "__main__":
+    main()

--- a/publisher.py
+++ b/publisher.py
@@ -1,0 +1,27 @@
+import json
+import random
+import time
+
+import paho.mqtt.client as mqtt
+
+BROKER_HOST = "192.168.1.100"  # 改为你的 Broker IP 或域名
+BROKER_PORT = 1883
+TOPIC = "home/sensor/temperature"
+
+
+def start_publisher(client: mqtt.Client) -> None:
+    """Publish random temperature data periodically."""
+    client.connect(BROKER_HOST, BROKER_PORT, 60)
+    client.loop_start()
+    try:
+        while True:
+            temperature = round(random.uniform(20.0, 30.0), 2)
+            payload = json.dumps({"temperature": temperature})
+            client.publish(TOPIC, payload)
+            print(f"已发布 → {TOPIC}: {payload}")
+            time.sleep(5)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        client.loop_stop()
+        client.disconnect()

--- a/subscriber.py
+++ b/subscriber.py
@@ -1,0 +1,29 @@
+import json
+
+import paho.mqtt.client as mqtt
+
+BROKER_HOST = "192.168.1.100"  # 改为你的 Broker IP 或域名
+BROKER_PORT = 1883
+TOPIC = "home/sensor/temperature"
+
+
+def on_connect(client: mqtt.Client, userdata, flags, rc) -> None:
+    print(f"Connected with result code {rc}")
+    client.subscribe(TOPIC)
+
+
+def on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
+    try:
+        data = json.loads(msg.payload.decode())
+        print(f"[{msg.topic}] 收到消息：{data}")
+    except json.JSONDecodeError:
+        print(f"[{msg.topic}] 未能解析消息：{msg.payload}")
+
+
+def start_subscriber() -> None:
+    """Listen to MQTT topic and print received messages."""
+    client = mqtt.Client()
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.connect(BROKER_HOST, BROKER_PORT, 60)
+    client.loop_forever()


### PR DESCRIPTION
## Summary
- reintroduce `publisher.py` and `subscriber.py`
- make `main.py` call those modules based on CLI mode
- update README explaining the new structure and configuration

## Testing
- `python3 -m py_compile main.py publisher.py subscriber.py`


------
https://chatgpt.com/codex/tasks/task_e_687890da4c2083319d0b57b8b257323d