### PR TITLE
Refactor publisher and subscriber into classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ args = parser.parse_args()
 ```python
 if args.mode == "publish":
     pub = publisher.MQTTPublisher(client=mqtt.Client())
-    pub.start()
+    pub.start(args.message)
 else:
     sub = subscriber.MQTTSubscriber()
     sub.start()
@@ -60,12 +60,13 @@ import random
 import paho.mqtt.client as mqtt
 
 client = mqtt.Client()
+publisher = MQTTPublisher(client=client)
 
-while True:
-    temperature = round(random.uniform(20.0, 30.0), 2)
-    payload = json.dumps({"temperature": temperature})
-    client.publish(TOPIC, payload)
-    time.sleep(5)
+# 发布单条自定义消息
+publisher.start('{"temperature": 23.0}')
+
+# 或循环发布随机温度
+publisher.start()
 ```
 
 `MQTTSubscriber.on_message()` 主要逻辑：
@@ -106,19 +107,10 @@ git clone https://github.com/yourusername/pi5-mqtt-tools.git
 cd pi5-mqtt-tools
 ```
 
-### 5. 配置 Broker 地址
-
-运行时可通过命令行参数指定 Broker 地址与端口，例如：
+### 5. 运行订阅者
 
 ```bash
-python3 main.py publish --host 192.168.1.100 --port 1883
-```
-若未指定，则默认使用 `192.168.1.100:1883`。
-
-### 6. 运行订阅者
-
-```bash
-python3 main.py subscribe --host 192.168.1.100
+python3 main.py subscribe --host 192.168.1.100 --port 1883 --topic home/sensor/temperature
 ```
 
 日志示例：
@@ -128,17 +120,12 @@ Connected with result code 0
 [home/sensor/temperature] 收到消息：25.34
 ```
 
-### 7. 运行发布者
+### 6. 运行发布者
 
 ```bash
-python3 main.py publish --host 192.168.1.100
+python3 main.py publish --host 192.168.1.100 --port 1883 --topic home/sensor/temperature --message '{"temperature": 27.5}'
 ```
-
-每隔 5 秒发布一次模拟温度：
-
-```
-已发布 → home/sensor/temperature: 27.81
-```
+若未指定 `--message`，则每隔 5 秒发布随机温度。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,18 @@ parser.add_argument("mode", choices=["publish", "subscribe"])
 args = parser.parse_args()
 ```
 
-根据参数决定调用 `publisher.start_publisher()` 或 `subscriber.start_subscriber()`。
+根据参数决定创建 `MQTTPublisher` 或 `MQTTSubscriber` 实例。
 
 ```python
 if args.mode == "publish":
-    publisher.start_publisher(mqtt.Client())
+    pub = publisher.MQTTPublisher(client=mqtt.Client())
+    pub.start()
 else:
-    subscriber.start_subscriber()
+    sub = subscriber.MQTTSubscriber()
+    sub.start()
 ```
 
-`start_publisher()` 主要逻辑：
+`MQTTPublisher.start()` 主要逻辑：
 
 ```python
 import json
@@ -66,7 +68,7 @@ while True:
     time.sleep(5)
 ```
 
-`start_subscriber()` 主要逻辑：
+`MQTTSubscriber.on_message()` 主要逻辑：
 
 ```python
 def on_message(client, userdata, msg):
@@ -106,18 +108,17 @@ cd pi5-mqtt-tools
 
 ### 5. 配置 Broker 地址
 
-编辑 `publisher.py` 和 `subscriber.py` 中的连接参数：
+运行时可通过命令行参数指定 Broker 地址与端口，例如：
 
-```python
-BROKER_HOST = "192.168.1.100"  # 改为你的 Broker IP 或域名
-BROKER_PORT = 1883
-TOPIC = "home/sensor/temperature"
+```bash
+python3 main.py publish --host 192.168.1.100 --port 1883
 ```
+若未指定，则默认使用 `192.168.1.100:1883`。
 
 ### 6. 运行订阅者
 
 ```bash
-python3 main.py subscribe
+python3 main.py subscribe --host 192.168.1.100
 ```
 
 日志示例：
@@ -130,7 +131,7 @@ Connected with result code 0
 ### 7. 运行发布者
 
 ```bash
-python3 main.py publish
+python3 main.py publish --host 192.168.1.100
 ```
 
 每隔 5 秒发布一次模拟温度：
@@ -146,7 +147,7 @@ python3 main.py publish
 1. **结构化 JSON 消息**：发送包含时间戳、传感器 ID 的 JSON 数据。
 2. **QoS 与遗嘱消息**：提高可靠性，处理断线场景。
 3. **GPIO 联动**：收到高温报警时控制风扇或 LED。\
-   示例可在 `start_subscriber()` 函数中添加 GPIO 控制逻辑。
+   示例可在 `MQTTSubscriber.on_message()` 中添加 GPIO 控制逻辑。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,15 @@ args = parser.parse_args()
 
 ```python
 if args.mode == "publish":
-    pub = publisher.MQTTPublisher(client=mqtt.Client())
+    pub = publisher.MQTTPublisher(
+        host=args.host,
+        port=args.port,
+        topic=args.topic,
+        client=mqtt.Client(),
+    )
     pub.start(args.message)
 else:
-    sub = subscriber.MQTTSubscriber()
+    sub = subscriber.MQTTSubscriber(host=args.host, port=args.port, topic=args.topic)
     sub.start()
 ```
 
@@ -60,7 +65,12 @@ import random
 import paho.mqtt.client as mqtt
 
 client = mqtt.Client()
-publisher = MQTTPublisher(client=client)
+publisher = MQTTPublisher(
+    host="192.168.1.100",
+    port=1883,
+    topic="home/sensor/temperature",
+    client=client,
+)
 
 # 发布单条自定义消息
 publisher.start('{"temperature": 23.0}')

--- a/config.py
+++ b/config.py
@@ -1,0 +1,3 @@
+DEFAULT_HOST = "192.168.1.100"
+DEFAULT_PORT = 1883
+DEFAULT_TOPIC = "home/sensor/temperature"

--- a/config.py
+++ b/config.py
@@ -1,3 +1,0 @@
-DEFAULT_HOST = "192.168.1.100"
-DEFAULT_PORT = 1883
-DEFAULT_TOPIC = "home/sensor/temperature"

--- a/main.py
+++ b/main.py
@@ -9,15 +9,23 @@ import subscriber
 def main() -> None:
     parser = argparse.ArgumentParser(description="MQTT 发布/订阅示例")
     parser.add_argument(
-        "mode", choices=["publish", "subscribe"], help="选择运行模式 (publish / subscribe)"
+        "mode",
+        choices=["publish", "subscribe"],
+        help="选择运行模式 (publish / subscribe)",
     )
+    parser.add_argument("--host", default=publisher.DEFAULT_HOST, help="MQTT Broker 地址")
+    parser.add_argument("--port", type=int, default=publisher.DEFAULT_PORT, help="MQTT Broker 端口")
+    parser.add_argument("--topic", default=publisher.DEFAULT_TOPIC, help="MQTT 主题")
     args = parser.parse_args()
 
     if args.mode == "publish":
-        client = mqtt.Client()
-        publisher.start_publisher(client)
+        pub = publisher.MQTTPublisher(
+            host=args.host, port=args.port, topic=args.topic, client=mqtt.Client()
+        )
+        pub.start()
     else:
-        subscriber.start_subscriber()
+        sub = subscriber.MQTTSubscriber(host=args.host, port=args.port, topic=args.topic)
+        sub.start()
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import paho.mqtt.client as mqtt
 
 import publisher
 import subscriber
+from config import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TOPIC
 
 
 def main() -> None:
@@ -13,16 +14,17 @@ def main() -> None:
         choices=["publish", "subscribe"],
         help="选择运行模式 (publish / subscribe)",
     )
-    parser.add_argument("--host", default=publisher.DEFAULT_HOST, help="MQTT Broker 地址")
-    parser.add_argument("--port", type=int, default=publisher.DEFAULT_PORT, help="MQTT Broker 端口")
-    parser.add_argument("--topic", default=publisher.DEFAULT_TOPIC, help="MQTT 主题")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="MQTT Broker 地址")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="MQTT Broker 端口")
+    parser.add_argument("--topic", default=DEFAULT_TOPIC, help="MQTT 主题")
+    parser.add_argument("--message", help="发布模式下要发送的消息")
     args = parser.parse_args()
 
     if args.mode == "publish":
         pub = publisher.MQTTPublisher(
             host=args.host, port=args.port, topic=args.topic, client=mqtt.Client()
         )
-        pub.start()
+        pub.start(args.message)
     else:
         sub = subscriber.MQTTSubscriber(host=args.host, port=args.port, topic=args.topic)
         sub.start()

--- a/main.py
+++ b/main.py
@@ -4,7 +4,11 @@ import paho.mqtt.client as mqtt
 
 import publisher
 import subscriber
-from config import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TOPIC
+
+# CLI 默认值，可根据实际部署环境调整
+DEFAULT_HOST = "192.168.1.100"
+DEFAULT_PORT = 1883
+DEFAULT_TOPIC = "home/sensor/temperature"
 
 
 def main() -> None:

--- a/publisher.py
+++ b/publisher.py
@@ -4,17 +4,15 @@ import time
 
 import paho.mqtt.client as mqtt
 
-from config import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TOPIC
-
 
 class MQTTPublisher:
     """定时发布随机温度数据或自定义消息。"""
 
     def __init__(
         self,
-        host: str = DEFAULT_HOST,
-        port: int = DEFAULT_PORT,
-        topic: str = DEFAULT_TOPIC,
+        host: str,
+        port: int,
+        topic: str,
         client: mqtt.Client | None = None,
     ) -> None:
         self.host = host
@@ -44,6 +42,6 @@ class MQTTPublisher:
             self.client.disconnect()
 
 
-def start_publisher(client: mqtt.Client) -> None:
-    """兼容旧接口，启动默认 ``MQTTPublisher``。"""
-    MQTTPublisher(client=client).start()
+def start_publisher(host: str, port: int, topic: str, client: mqtt.Client) -> None:
+    """兼容旧接口，按给定参数启动 ``MQTTPublisher``。"""
+    MQTTPublisher(host=host, port=port, topic=topic, client=client).start()

--- a/publisher.py
+++ b/publisher.py
@@ -4,14 +4,11 @@ import time
 
 import paho.mqtt.client as mqtt
 
-# 默认连接参数，可在实例化 ``MQTTPublisher`` 时覆盖
-DEFAULT_HOST = "192.168.1.100"
-DEFAULT_PORT = 1883
-DEFAULT_TOPIC = "home/sensor/temperature"
+from config import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TOPIC
 
 
 class MQTTPublisher:
-    """定时发布随机温度数据。"""
+    """定时发布随机温度数据或自定义消息。"""
 
     def __init__(
         self,
@@ -25,17 +22,21 @@ class MQTTPublisher:
         self.topic = topic
         self.client = client or mqtt.Client()
 
-    def start(self) -> None:
-        """连接到 Broker 并循环发布消息。"""
+    def start(self, message: str | None = None) -> None:
+        """连接到 Broker 并发送消息。"""
         self.client.connect(self.host, self.port, 60)
         self.client.loop_start()
         try:
-            while True:
-                temperature = round(random.uniform(20.0, 30.0), 2)
-                payload = json.dumps({"temperature": temperature})
-                self.client.publish(self.topic, payload)
-                print(f"已发布 → {self.topic}: {payload}")
-                time.sleep(5)
+            if message is not None:
+                self.client.publish(self.topic, message)
+                print(f"已发布 → {self.topic}: {message}")
+            else:
+                while True:
+                    temperature = round(random.uniform(20.0, 30.0), 2)
+                    payload = json.dumps({"temperature": temperature})
+                    self.client.publish(self.topic, payload)
+                    print(f"已发布 → {self.topic}: {payload}")
+                    time.sleep(5)
         except KeyboardInterrupt:
             pass
         finally:

--- a/publisher.py
+++ b/publisher.py
@@ -4,24 +4,45 @@ import time
 
 import paho.mqtt.client as mqtt
 
-BROKER_HOST = "192.168.1.100"  # 改为你的 Broker IP 或域名
-BROKER_PORT = 1883
-TOPIC = "home/sensor/temperature"
+# 默认连接参数，可在实例化 ``MQTTPublisher`` 时覆盖
+DEFAULT_HOST = "192.168.1.100"
+DEFAULT_PORT = 1883
+DEFAULT_TOPIC = "home/sensor/temperature"
+
+
+class MQTTPublisher:
+    """定时发布随机温度数据。"""
+
+    def __init__(
+        self,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+        topic: str = DEFAULT_TOPIC,
+        client: mqtt.Client | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.topic = topic
+        self.client = client or mqtt.Client()
+
+    def start(self) -> None:
+        """连接到 Broker 并循环发布消息。"""
+        self.client.connect(self.host, self.port, 60)
+        self.client.loop_start()
+        try:
+            while True:
+                temperature = round(random.uniform(20.0, 30.0), 2)
+                payload = json.dumps({"temperature": temperature})
+                self.client.publish(self.topic, payload)
+                print(f"已发布 → {self.topic}: {payload}")
+                time.sleep(5)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.client.loop_stop()
+            self.client.disconnect()
 
 
 def start_publisher(client: mqtt.Client) -> None:
-    """Publish random temperature data periodically."""
-    client.connect(BROKER_HOST, BROKER_PORT, 60)
-    client.loop_start()
-    try:
-        while True:
-            temperature = round(random.uniform(20.0, 30.0), 2)
-            payload = json.dumps({"temperature": temperature})
-            client.publish(TOPIC, payload)
-            print(f"已发布 → {TOPIC}: {payload}")
-            time.sleep(5)
-    except KeyboardInterrupt:
-        pass
-    finally:
-        client.loop_stop()
-        client.disconnect()
+    """兼容旧接口，启动默认 ``MQTTPublisher``。"""
+    MQTTPublisher(client=client).start()

--- a/subscriber.py
+++ b/subscriber.py
@@ -2,17 +2,15 @@ import json
 
 import paho.mqtt.client as mqtt
 
-from config import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TOPIC
-
 
 class MQTTSubscriber:
     """订阅指定主题并打印收到的消息。"""
 
     def __init__(
         self,
-        host: str = DEFAULT_HOST,
-        port: int = DEFAULT_PORT,
-        topic: str = DEFAULT_TOPIC,
+        host: str,
+        port: int,
+        topic: str,
     ) -> None:
         self.host = host
         self.port = port
@@ -38,6 +36,6 @@ class MQTTSubscriber:
         self.client.loop_forever()
 
 
-def start_subscriber() -> None:
-    """兼容旧接口，启动默认 ``MQTTSubscriber``。"""
-    MQTTSubscriber().start()
+def start_subscriber(host: str, port: int, topic: str) -> None:
+    """兼容旧接口，按给定参数启动 ``MQTTSubscriber``。"""
+    MQTTSubscriber(host=host, port=port, topic=topic).start()

--- a/subscriber.py
+++ b/subscriber.py
@@ -2,10 +2,7 @@ import json
 
 import paho.mqtt.client as mqtt
 
-# 默认连接参数，可在实例化 ``MQTTSubscriber`` 时覆盖
-DEFAULT_HOST = "192.168.1.100"
-DEFAULT_PORT = 1883
-DEFAULT_TOPIC = "home/sensor/temperature"
+from config import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TOPIC
 
 
 class MQTTSubscriber:


### PR DESCRIPTION
## Summary
- implement `MQTTPublisher` and `MQTTSubscriber` classes
- allow broker host and port to be passed at runtime via CLI
- update main entry to use the new classes
- document new usage

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6879ba26b4b8833193b7a7f0447ae0c8