### PR TITLE
Fix imports and update documentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,13 @@
+"""命令行入口：按参数发布或订阅 MQTT 消息。"""
+
+import argparse
+import time
+
+import paho.mqtt.client as mqtt
+
+from subscriber import MQTTSubscriber
+
+
 def publish_message(host: str, port: int, topic: str, message: str) -> None:
     """
     简单发布函数：连接、发布、断开

--- a/publisher.py
+++ b/publisher.py
@@ -1,5 +1,4 @@
 import json
-import random
 import paho.mqtt.client as mqtt
 
 class MQTTPublisher:


### PR DESCRIPTION
## Summary
- restore missing imports in `main.py`
- clean up unused imports in `publisher.py`
- update README instructions and examples for new design

## Testing
- `python3 -m py_compile main.py publisher.py subscriber.py`
- `pip3 install paho-mqtt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879e5ac02a48331920c24dd82b1e0ae